### PR TITLE
feat(docker): add docker container support for the server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM pytorch/pytorch:1.13.1-cuda11.6-cudnn8-runtime
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONPATH="/app/src:$PYTHONPATH"
+
+ENV PORT=3002
+EXPOSE 3002
+
+WORKDIR src/spel
+
+# Download all necessary files, prime the model
+RUN python prime.py || true
+
+CMD ["python", "server.py", "spel", "n"]
+
+# docker build --platform=linux/amd64 -t spel .
+# docker run -t -p 8002:3002 spel

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ torchdata==0.5.1
 mosestokenizer==1.2.1
 wandb==0.15.7
 st-annotated-text
+flask
+flask-cors
+pynif

--- a/src/spel/prime.py
+++ b/src/spel/prime.py
@@ -1,0 +1,11 @@
+import torch
+
+from model import SpELAnnotator
+
+device = torch.device("cpu")
+
+annotator = SpELAnnotator()
+annotator.load_checkpoint(None,
+                          device=device,
+                          load_from_torch_hub=True,
+                          finetuned_after_step=4)

--- a/src/spel/server.py
+++ b/src/spel/server.py
@@ -26,9 +26,11 @@ from gerbil_connect.nif_parser import NIFParser
 from spel.configuration import device, get_n3_entity_to_kb_mappings
 from spel.candidate_manager import CandidateManager
 
+PORT = int(os.environ.get("PORT", 3002))
+
 cli = sys.modules['flask.cli']
 cli.show_server_banner = lambda *x: click.echo(
-    " * You may perform entity linking through: http://localhost:3002/annotate_[aida,wiki,dbpedia,n3]")
+    f" * You may perform entity linking through: http://localhost:{PORT}/annotate_[aida,wiki,dbpedia,n3]")
 app = Flask(__name__, static_url_path='', static_folder='../../../frontend/build')
 cors = CORS(app, resources={r"/suggest": {"origins": "*"}})
 app.config['CORS_HEADERS'] = 'Content-Type'
@@ -144,7 +146,7 @@ def annotate_n3():
 
 if __name__ == '__main__':
     try:
-        app.run(host="localhost", port=int(os.environ.get("PORT", 3002)), debug=False)
+        app.run(host="0.0.0.0", port=PORT, debug=False)
     finally:
         if annotate_result:
             with open(f"annotate_{annotator_name}_result.json", "w", encoding="utf-8") as f:


### PR DESCRIPTION
I would like to set up a web server to run SpEL.

I created a Dockerfile allowing to build and run the server, with a riming mechanism to download the necessary models.

Run
```sh
docker build --platform=linux/amd64 -t spel .
docker run -t -p 8002:3002 spel
```

Then, you should be able to make a request
```py
from pynif import NIFCollection

# Create a NIF collection with one context
collection = NIFCollection()
context = collection.add_context(
    uri="http://freme-project.eu/doc32",
    mention="Diego Maradona is from Argentina.")

# Serialize to Turtle (text/turtle)
nif_turtle = collection.dumps(format='turtle')

# Example: send via HTTP request
import requests

response = requests.post(
    "http://127.0.0.1:8002/annotate_dbpedia",
    data=nif_turtle,
    headers={"Content-Type": "application/x-turtle"}
)

# Check response
if response.status_code == 200:
    print("Annotation successful!")
    print(response.text)
else:
    print("Error:", response.status_code, response.text)
```

However, it fails, with:
```python
ERROR in app: Exception on /annotate_dbpedia [POST]
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/conda/lib/python3.10/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/conda/lib/python3.10/site-packages/flask_cors/extension.py", line 176, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/opt/conda/lib/python3.10/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/conda/lib/python3.10/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/opt/conda/lib/python3.10/site-packages/flask_cors/decorator.py", line 121, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/app/src/spel/server.py", line 136, in annotate_dbpedia
    return generic_annotate(request.data, True, "http://dbpedia.org/resource/", True)
  File "/app/src/spel/server.py", line 97, in generic_annotate
    annotator.annotate(parsed_collection, ignore_non_aida_vocab=not load_full_vocabulary, kb_prefix=kb_prefix,
  File "/app/src/spel/evaluate_local.py", line 39, in annotate
    phrase_annotations = chunk_annotate_and_merge_to_phrase(
  File "/app/src/spel/utils.py", line 283, in chunk_annotate_and_merge_to_phrase
    simple_split_words = moses_tokenize(sentence)
  File "/opt/conda/lib/python3.10/site-packages/mosestokenizer/tokenizer.py", line 75, in __call__
    self.writeline(sentence)
  File "/opt/conda/lib/python3.10/site-packages/toolwrapper.py", line 141, in writeline
    self.stdin.write(line + "\n")
BrokenPipeError: [Errno 32] Broken pipe
```